### PR TITLE
Feature/check ref type and impl skip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "fluent_field_assertions"
-version = "0.1.4"
+name = "derive-getters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "fluent_field_assertions"
+version = "0.2.0"
+dependencies = [
+ "derive-getters",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 FluentFieldAssertions is a library that allows you to write tests in a natural language-like syntax.
 With this library, you can perform field assertions in an intuitive and readable way.
 """
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Daisuke Ito <daisuke.ito.cs@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ quote = "1"
 syn = "2"
 
 [dev-dependencies]
+derive-getters = "0"
 rstest = "0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ FluentFieldAssertions generated the following methods for each field.
 ```rust
 use fluent_field_assertions::FluentFieldAssertions;
 
-#[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+#[derive(FluentFieldAssertions)]
 struct User {
     id: usize,
     name: String,
@@ -37,8 +37,8 @@ let user = User {
 };
 
 // You can write tests in a natural language-like syntax.
-user.id_eq(1)
-    .name_eq("Alice".to_string())
+user.id_eq(&1)
+    .name_eq(&"Alice".to_string())
     .age_satisfies(|age| age < &18);
 
 // Same as above.
@@ -57,25 +57,29 @@ Each field must implement the traits `Eq` and `Display`.
 ```rust
 use fluent_field_assertions::FluentFieldAssertions;
 
-#[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+#[derive(FluentFieldAssertions)]
 struct User {
     id: usize,
     name: String,
     age: usize,
+    // You can skip assertion_methods for some fields.
+    #[assertions(skip)]
+    score: f64,
 }
 
 let user = User {
     id: 1,
     name: "Alice".to_string(),
     age: 17,
+    score: 95.0,
 };
 
 // You can use `{field}_eq` to assert_eq!.
-user.name_eq("Alice".to_string());
+user.name_eq(&"Alice".to_string());
 assert_eq!(user.name, "Alice".to_string()); // Same as above.
 
 // You can use `{field}_ne` to assert_ne!.
-user.name_ne("Bob".to_string());
+user.name_ne(&"Bob".to_string());
 assert_ne!(user.name, "Bob".to_string()); // Same as above.
 
 // You can use `{field}_satisfies` to assert!.
@@ -83,8 +87,8 @@ user.name_satisfies(|name| name.starts_with('A'));
 assert!(user.name.starts_with('A')); // Same as above.
 
 // You can chain assertions as method calls.
-user.id_eq(1)
-    .name_eq("Alice".to_string())
+user.id_eq(&1)
+    .name_eq(&"Alice".to_string())
     .age_satisfies(|age| age < &18);
 
 // Same as above.
@@ -102,7 +106,7 @@ In that case, Generics type `T` must implement the traits `Eq` and `Display`.
 use core::fmt::Debug;
 use fluent_field_assertions::FluentFieldAssertions;
 
-#[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+#[derive(FluentFieldAssertions)]
 struct Point<T>
 // Generics type `T` must implement trait `Eq` and `Display`.
 where
@@ -111,9 +115,18 @@ where
     x: T,
     y: T,
     z: T,
+    // You can skip assertion_methods for some fields.
+    #[assertions(skip)]
+    #[allow(dead_code)]
+    t: T,
 }
 
-let point = Point { x: 1, y: 2, z: 3 };
+let point = Point {
+    x: 1,
+    y: 2,
+    z: 3,
+    t: 4,
+};
 
-point.x_eq(1).y_ne(9).z_satisfies(|z| z % 3 == 0);
+point.x_eq(&1).y_ne(&9).z_satisfies(|z| z % 3 == 0);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,20 +17,28 @@ extern crate proc_macro2;
 /// ```rust
 /// use fluent_field_assertions::FluentFieldAssertions;
 ///
-/// #[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+/// #[derive(FluentFieldAssertions)]
 /// struct User {
 ///     id: usize,
 ///     name: String,
+///     age: usize,
+///     // You can skip assertions for some fields.
+///     #[assertions(skip)]
+///     score: f64,
 /// }
 ///
 /// let user = User {
 ///     id: 1,
 ///     name: "Alice".to_string(),
+///     age: 17,
+///     score: 95.0,
 /// };
 ///
-/// user.name_eq("Alice".to_string())
-///     .name_ne("Bob".to_string())
-///     .name_satisfies(|name| name.starts_with("A"));
+/// user.id_eq(&1)
+///     .name_eq(&"Alice".to_string())
+///     .name_ne(&"Bob".to_string())
+///     .name_satisfies(|name| name.starts_with("A"))
+///     .age_eq(&17);
 /// ```
 ///
 /// # Example for generics struct
@@ -38,18 +46,25 @@ extern crate proc_macro2;
 /// use core::fmt::Debug;
 /// use fluent_field_assertions::FluentFieldAssertions;
 ///
-/// #[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+/// #[derive(FluentFieldAssertions)]
 /// struct Point<T>
+/// // Generics type `T` must implement trait `Eq` and `Display`.
 /// where
 ///     T: Eq + Debug,
 /// {
 ///     x: T,
 ///     y: T,
+///     z: T,
+///     // You can skip assertions for some fields.
+///     #[assertions(skip)]
+///     t: T,
 /// }
 ///
-/// let point = Point { x: 1, y: 2 };
+/// let point = Point { x: 1, y: 2, z: 3, t: 4 };
 ///
-/// point.x_eq(1).y_ne(9).x_satisfies(|x| x > &0);
+/// point.x_eq(&1)
+///     .y_ne(&9) // Note that `y` is NOT `9`.
+///     .z_satisfies(|z| z > &0);
 /// ```
 #[proc_macro_derive(FluentFieldAssertions, attributes(assertions))]
 pub fn fluent_field_assertions(input: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ fn generate_methods(field: &Field) -> Vec<TokenStream2> {
     });
 
     if skip {
-        return vec![];
+        vec![]
     } else {
         vec![
             generate_eq_method(&field_name, &field_type),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,11 +125,9 @@ fn generate_eq_method(field_name: &Ident, field_type: &Type) -> TokenStream2 {
 
     quote! {
         #[inline(always)]
-        pub fn #method_name(&self, expected: #field_type) -> &Self
-        where
-            #field_type: Eq + core::fmt::Debug
+        pub fn #method_name(&self, expected: &#field_type) -> &Self
         {
-            assert_eq!(self.#field_name, expected);
+            assert_eq!(&self.#field_name, expected);
             self
         }
     }
@@ -140,11 +138,9 @@ fn generate_ne_method(field_name: &Ident, field_type: &Type) -> TokenStream2 {
 
     quote! {
         #[inline(always)]
-        pub fn #method_name(&self, expected: #field_type) -> &Self
-        where
-            #field_type: Eq + core::fmt::Debug
+        pub fn #method_name(&self, expected: &#field_type) -> &Self
         {
-            assert_ne!(self.#field_name, expected);
+            assert_ne!(&self.#field_name, expected);
             self
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ fn generate_eq_method(field_name: &Ident, field_type: &Type) -> TokenStream2 {
 
     quote! {
         #[inline(always)]
+        #[track_caller]
         pub fn #method_name(&self, expected: &#field_type) -> &Self
         {
             assert_eq!(&self.#field_name, expected);
@@ -138,6 +139,7 @@ fn generate_ne_method(field_name: &Ident, field_type: &Type) -> TokenStream2 {
 
     quote! {
         #[inline(always)]
+        #[track_caller]
         pub fn #method_name(&self, expected: &#field_type) -> &Self
         {
             assert_ne!(&self.#field_name, expected);
@@ -151,6 +153,7 @@ fn generate_satisfies_method(field_name: &Ident, field_type: &Type) -> TokenStre
 
     quote! {
         #[inline(always)]
+        #[track_caller]
         pub fn #method_name(&self, pred: impl FnOnce(&#field_type) -> bool) -> &Self {
             assert!(pred(&self.#field_name));
             self

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,14 @@
 use core::fmt::Debug;
 use fluent_field_assertions::FluentFieldAssertions;
 
-#[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+#[allow(unused)]
+#[derive(FluentFieldAssertions)]
 struct User {
     id: usize,
     name: String,
 }
 
-#[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+#[derive(FluentFieldAssertions)]
 struct Container<T>
 where
     T: Eq + Debug,
@@ -38,7 +39,7 @@ mod test {
     #[should_panic]
     #[case::invalid_name("Bob".to_string())]
     fn can_be_checked_equal_of_struct(#[case] expected: String) {
-        alice().name_eq(expected);
+        alice().name_eq(&expected);
     }
 
     #[rstest]
@@ -46,7 +47,7 @@ mod test {
     #[case::valid_name("Alice".to_string())]
     #[case::invalid_name("Bob".to_string())]
     fn can_be_checked_not_equal_of_struct(#[case] expected: String) {
-        alice().name_ne(expected);
+        alice().name_ne(&expected);
     }
 
     #[rstest]
@@ -54,7 +55,7 @@ mod test {
     #[should_panic]
     #[case::invalid_value("Hello, Rust!".to_string())]
     fn can_be_checked_equal_of_generics_struct(#[case] expected: String) {
-        hello_world().value_eq(expected);
+        hello_world().value_eq(&expected);
     }
 
     #[rstest]
@@ -62,7 +63,7 @@ mod test {
     #[case::valid_value("Hello, world!".to_string())]
     #[case::invalid_value("Hello, Rust!".to_string())]
     fn can_be_checked_not_equal_of_generics_struct(#[case] expected: String) {
-        hello_world().value_ne(expected);
+        hello_world().value_ne(&expected);
     }
 
     #[test]
@@ -74,7 +75,7 @@ mod test {
     fn uses_in_readme_work_properly() {
         use fluent_field_assertions::FluentFieldAssertions;
 
-        #[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+        #[derive(FluentFieldAssertions)]
         struct User {
             id: usize,
             name: String,
@@ -88,8 +89,8 @@ mod test {
         };
 
         // You can write tests in a natural language-like syntax.
-        user.id_eq(1)
-            .name_eq("Alice".to_string())
+        user.id_eq(&1)
+            .name_eq(&"Alice".to_string())
             .age_satisfies(|age| age < &18);
 
         // Same as above.
@@ -102,25 +103,30 @@ mod test {
     fn struct_examples_in_readme_work_properly() {
         use fluent_field_assertions::FluentFieldAssertions;
 
-        #[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+        #[derive(FluentFieldAssertions)]
         struct User {
             id: usize,
             name: String,
             age: usize,
+            // You can skip assertion_methods for some fields.
+            #[assertions(skip)]
+            #[allow(dead_code)]
+            score: f64,
         }
 
         let user = User {
             id: 1,
             name: "Alice".to_string(),
             age: 17,
+            score: 95.0,
         };
 
         // You can use `{field}_eq` to assert_eq!.
-        user.name_eq("Alice".to_string());
+        user.name_eq(&"Alice".to_string());
         assert_eq!(user.name, "Alice".to_string()); // Same as above.
 
         // You can use `{field}_ne` to assert_ne!.
-        user.name_ne("Bob".to_string());
+        user.name_ne(&"Bob".to_string());
         assert_ne!(user.name, "Bob".to_string()); // Same as above.
 
         // You can use `{field}_satisfies` to assert!.
@@ -128,8 +134,8 @@ mod test {
         assert!(user.name.starts_with('A')); // Same as above.
 
         // You can chain assertions as method calls.
-        user.id_eq(1)
-            .name_eq("Alice".to_string())
+        user.id_eq(&1)
+            .name_eq(&"Alice".to_string())
             .age_satisfies(|age| age < &18);
 
         // Same as above.
@@ -143,7 +149,7 @@ mod test {
         use core::fmt::Debug;
         use fluent_field_assertions::FluentFieldAssertions;
 
-        #[derive(FluentFieldAssertions, Debug, Eq, PartialEq)]
+        #[derive(FluentFieldAssertions)]
         struct Point<T>
         // Generics type `T` must implement trait `Eq` and `Display`.
         where
@@ -152,10 +158,19 @@ mod test {
             x: T,
             y: T,
             z: T,
+            // You can skip assertion_methods for some fields.
+            #[assertions(skip)]
+            #[allow(dead_code)]
+            t: T,
         }
 
-        let point = Point { x: 1, y: 2, z: 3 };
+        let point = Point {
+            x: 1,
+            y: 2,
+            z: 3,
+            t: 4,
+        };
 
-        point.x_eq(1).y_ne(9).z_satisfies(|z| z % 3 == 0);
+        point.x_eq(&1).y_ne(&9).z_satisfies(|z| z % 3 == 0);
     }
 }


### PR DESCRIPTION
- Change to assert with ref type.
- Skip implementation of assertion methods .
- Add track_call to find error easier.
- Update to v2.0.0.